### PR TITLE
Remove drat from readme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,7 @@ Depends:
     ggplot2,
     scales,
     binom,
-    lubridate,
-    covidregionaldata
+    lubridate
 License: MIT
 ByteCompile: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,10 @@ Depends:
     ggplot2,
     scales,
     binom,
-    lubridate
+    lubridate,
+    covid19.nhs.data
+Remotes:
+    epiforecasts/covid19.nhs.data
 License: MIT
 ByteCompile: true
 Encoding: UTF-8

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,16 +21,7 @@ Funk S, Flasche S,  _`r Title`_. Available at <https://cmmid.github.io/topics/co
 
 ### How to download or install
 
-The code depends on the `covidregionaldata` package, which can be installed using
-
-```{r covidregionaldata-install, eval = FALSE}
-# install.packages("drat")
-library("drat")
-drat:::add("epiforecasts")
-install.packages("covidregionaldata")
-```
-
-The code itself is installed as an R package, `covid19.lfd.education`, from GitHub with:
+The code is installed as an R package, `covid19.lfd.education`, from GitHub with:
 
 ```{r gh-installation, eval = FALSE}
 # install.packages("devtools")

--- a/README.md
+++ b/README.md
@@ -15,17 +15,7 @@ evidence of high test specificity*. Available at
 
 ### How to download or install
 
-The code depends on the `covidregionaldata` package, which can be
-installed using
-
-``` r
-# install.packages("drat")
-library("drat")
-drat:::add("epiforecasts")
-install.packages("covidregionaldata")
-```
-
-The code itself is installed as an R package, `covid19.lfd.education`,
+The code is installed as an R package, `covid19.lfd.education`,
 from GitHub with:
 
 ``` r


### PR DESCRIPTION
The drat is no longer up to date and I think as written using the description will pull the cran version of covidregionaldata with no issue. If wanting the development version (maybe to get data fixs?) Should change to the universe and specify that as a repository in the description. 